### PR TITLE
Bump drush minimum requirement to 12.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,6 @@
         "drupal/coder": "^8.3",
         "drupal/core-dev": "^10.2",
         "drupal/webprofiler": "^10.1",
-        "drush/drush": "^12.4"
+        "drush/drush": "^12.5"
     }
 }


### PR DESCRIPTION
Errors regarding missing AutoWireTrait pop up when running Drush 12.4. Running `drush en devel` produces this error on 12.4.3.0. Updating to 12.5.1.0 resolved this, so I think we should have 12.5 as the minimum version.